### PR TITLE
Don’t respond to input via contentEditable elements

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,8 @@ const WordListener = function ({ word, callback } = {}) {
 	this.callback = callback;
 	this.index = 0;
 	this.listener = ({ key, target }) => {
-		const shouldIgnoreKey = ignoreList.includes(target.tagName.toLowerCase());
+		const targetTag = target && target.tagName.toLowerCase();
+		const shouldIgnoreKey = ignoreList.includes(targetTag) || target.contentEditable === 'true';
 
 		if (shouldIgnoreKey) {
 			this.index = 0;


### PR DESCRIPTION
Fixes a problem in FT.com article comments, where user input is not
via the `<input>` tag. For some reason. Oh, Internet, I’m sorry we do these
things to you 🌹